### PR TITLE
doc: add ACRN Sample App doc to toctree

### DIFF
--- a/doc/try.rst
+++ b/doc/try.rst
@@ -15,6 +15,7 @@ hypervisor, the Service VM, and a User VM on a supported Intel target platform.
    reference/hardware
    getting-started/overview_dev
    getting-started/getting-started
+   misc/sample_application/README
 
 After getting familiar with ACRN development, check out these
 :ref:`develop_acrn` for information about more-advanced scenarios and enabling

--- a/misc/sample_application/README.rst
+++ b/misc/sample_application/README.rst
@@ -1,12 +1,22 @@
+.. _sample-app:
+
 ACRN Sample Application
 #######################
 
-This directory contains a software application that runs a real-time application between a real-time VM and a standard VM using the acrn-hypervisor.
+This directory contains a software application that runs a real-time
+application between a real-time VM and a standard VM using the
+acrn-hypervisor.
 
-The ``rtvm`` directory contains the code that reads and pipes data from ``cyclictest`` to the User VM using the inter-vm shared memory feature that acrn-hypervisor exposes to its VMs.
+The ``rtvm`` directory contains the code that reads and pipes data from
+``cyclictest`` to the User VM using the inter-vm shared memory feature that
+acrn-hypervisor exposes to its VMs.
 
-The ``uservm`` directory contains the code that reads the piped data from the RTVM, processes the data, and displays the data over a web application that can be accessed from the hypervisor's Service VM.
+The ``uservm`` directory contains the code that reads the piped data from the
+RTVM, processes the data, and displays the data over a web application that
+can be accessed from the hypervisor's Service VM.
 
-To build and run the applications, copy this repo to your VMs, run make in the directory that corresponds to the VM that you are running, and then follow the sample app guide in the acrn-hypervisor documentation.
+To build and run the applications, copy this repo to your VMs, run make in the
+directory that corresponds to the VM that you are running, and then follow the
+sample app guide in the acrn-hypervisor documentation.
 
 For more information, please go to: https://github.com/projectacrn/acrn-hypervisor/wiki/ACRN-Sample-App


### PR DESCRIPTION
Add the ACRN Sample App document (README.rst) to the toctree
Convert the README.rst from Dos to Unix text file format

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>